### PR TITLE
Make aws-assume usable as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ $ aws-assume <profile>
 ```
 
 ## Installation
-```
-# As part of your Node project
-npm install aws-assume --save
 
+### As part of your Node project
+`npm install aws-assume --save`
+
+#### Usage as a standalone CLI script
+```javascript
 # package.json
 ...
     "scripts": {
@@ -27,8 +29,22 @@ npm install aws-assume --save
 ...
 ```
 
+#### Usage as a module
+```javascript
+import {assumeRole, getProfile} from 'aws-assume'
+import AWS from 'aws-sdk'
+
+...
+
+assumeRole(getProfile())
+.then(credentials => {
+	AWS.config.credentials = credentials
+	// ...
+})
 ```
-# Install globally
+
+### Install globally
+```bash
 npm install -g aws-assume
 eval "`aws-assume <profile>` npm run deploy"
 ```

--- a/bin/aws-assume
+++ b/bin/aws-assume
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 
 const assume = require('../lib/aws-assume.js')
-const credentials = assume.default(assume.getProfile())
+const profile = process.argv.length > 2 ? process.argv[2] : assume.getProfile()
+const credentials = assume.default(profile)

--- a/src/aws-assume.js
+++ b/src/aws-assume.js
@@ -7,7 +7,7 @@ import { join, dirname } from 'path'
 import { readFileSync } from 'fs'
 import { parse } from 'ini'
 
-function assume(profile) {
+export function assumeRole(profile) {
   const creds = new SharedIniFileCredentials({ profile })
   const file = process.env.AWS_CONFIG_FILE || join(dirname(creds.filename), 'config')
   const config = parse(readFileSync(file, 'utf-8'))[`profile ${profile}`]
@@ -27,12 +27,7 @@ function assume(profile) {
 }
 
 export function getProfile() {
-  if (process.argv.length > 2) {
-    return process.argv[2]
-  } else if (process.env.AWS_PROFILE) {
-    return process.env.AWS_PROFILE
-  }
-  return 'default'
+  return process.env.AWS_PROFILE || 'default'
 }
 
 export default async (profile) => {
@@ -40,7 +35,7 @@ export default async (profile) => {
   process.stdin.setEncoding('utf8')
 
   try {
-    const { AccessKeyId, SecretAccessKey, SessionToken } = await assume(profile)
+    const { AccessKeyId, SecretAccessKey, SessionToken } = await assumeRole(profile)
     process.stdout.write(`AWS_ACCESS_KEY_ID=${AccessKeyId} AWS_SECRET_ACCESS_KEY=${SecretAccessKey} AWS_SESSION_TOKEN=${SessionToken}`)
   } catch(e) {
     process.stderr.write(e.message + "\n")

--- a/src/aws-assume.js
+++ b/src/aws-assume.js
@@ -2,7 +2,7 @@
 
 'use strict'
 import 'babel-polyfill'
-import { SharedIniFileCredentials, STS } from 'aws-sdk'
+import { Credentials, SharedIniFileCredentials, STS } from 'aws-sdk'
 import { join, dirname } from 'path'
 import { readFileSync } from 'fs'
 import { parse } from 'ini'
@@ -25,7 +25,7 @@ export function assumeRole(profile) {
   return new Promise((resolve, reject) => {
     sts.assumeRole(options, (error, response) => {
       if (error) reject(error)
-      else resolve(response.Credentials)
+      else resolve(new Credentials(response.Credentials.AccessKeyId, response.Credentials.SecretAccessKey, response.Credentials.SessionToken))
     })
   })
 }
@@ -39,8 +39,8 @@ export default async (profile) => {
   process.stdin.setEncoding('utf8')
 
   try {
-    const { AccessKeyId, SecretAccessKey, SessionToken } = await assumeRole(profile)
-    process.stdout.write(`AWS_ACCESS_KEY_ID=${AccessKeyId} AWS_SECRET_ACCESS_KEY=${SecretAccessKey} AWS_SESSION_TOKEN=${SessionToken}`)
+    const { accessKeyId, secretAccessKey, sessionToken } = await assumeRole(profile)
+    process.stdout.write(`AWS_ACCESS_KEY_ID=${accessKeyId} AWS_SECRET_ACCESS_KEY=${secretAccessKey} AWS_SESSION_TOKEN=${sessionToken}`)
   } catch(e) {
     process.stderr.write(e.message + "\n")
     process.exitCode = 1

--- a/src/aws-assume.js
+++ b/src/aws-assume.js
@@ -6,10 +6,14 @@ import { SharedIniFileCredentials, STS } from 'aws-sdk'
 import { join, dirname } from 'path'
 import { readFileSync } from 'fs'
 import { parse } from 'ini'
+import { homedir } from 'os'
 
 export function assumeRole(profile) {
   const creds = new SharedIniFileCredentials({ profile })
-  const file = process.env.AWS_CONFIG_FILE || join(dirname(creds.filename), 'config')
+
+  const awsProfileDir = creds.filename ? dirname(creds.filename) : join(homedir(), '.aws')
+  const file = process.env.AWS_CONFIG_FILE || join(awsProfileDir, 'config')
+
   const config = parse(readFileSync(file, 'utf-8'))[`profile ${profile}`]
   const sts = new STS()
 


### PR DESCRIPTION
Getting temporary credentials for AssumeRole profiles is useful beyond spitting them out on the CLI.

This PR  renames the _assume()_ function to _assumeRole()_, exposes it as an export and moves CLI argument parsing out of the function. This lets other node scripts acquire TemporaryCredentials for any one of the users' profiles. For added convenience, the Promise resolves with a pre-wrapped _Crendentials_ object, which can be directly passed on to the aws-sdk.

The PR also includes a bug fix for cases in which the _SharedIniFileCredentials_ object has an undefined _.filename_ property. This seems to always be the case (at least on Windows), unless one specifically passes _options.filename_ into the _SharedIniFileCredentials_ constructor. 