### PR TITLE
expose AWS global configuration object on the module API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,22 @@ $ aws-assume <profile>
 
 #### Usage as a module
 ```javascript
-import {assumeRole, getProfile} from 'aws-assume'
+import {assumeRole, getProfile, awsConfig} from 'aws-assume'
 import AWS from 'aws-sdk'
 
 ...
+// aws-assume exposes the AWS SDK global configuration object
+// so you can customize details such as proxies, loggers and retry options
+awsConfig.update({
+    httpOptions: { 
+        agent: myProxy
+    }
+});
 
 assumeRole(getProfile())
 .then(credentials => {
-	AWS.config.credentials = credentials
-	// ...
+    AWS.config.credentials = credentials
+    // ...
 })
 ```
 

--- a/src/aws-assume.js
+++ b/src/aws-assume.js
@@ -7,6 +7,7 @@ import { join, dirname } from 'path'
 import { readFileSync } from 'fs'
 import { parse } from 'ini'
 import { homedir } from 'os'
+export { config as awsConfig } from 'aws-sdk';
 
 export function assumeRole(profile) {
   const creds = new SharedIniFileCredentials({ profile })


### PR DESCRIPTION
This small PR lets the user customize details of the AWS SDK such as proxies (in my case), loggers and retry options by exposing the global AWS configuration object as an export. 